### PR TITLE
add: game logic, refactor model, add event

### DIFF
--- a/dojo-starter/src/models.cairo
+++ b/dojo-starter/src/models.cairo
@@ -3,7 +3,6 @@ use starknet::ContractAddress;
 #[derive(Copy, Drop, Serde, Debug)]
 #[dojo::model]
 pub struct Piece {
-    #[key]
     pub player: ContractAddress,
     #[key]
     pub coordinates: Coordinates,

--- a/dojo-starter/src/models.cairo
+++ b/dojo-starter/src/models.cairo
@@ -31,21 +31,21 @@ impl PositionIntoFelt252 of Into<Position, felt252> {
 
 #[derive(Copy, Drop, Serde, IntrospectPacked, Debug)]
 pub struct Coordinates {
-    pub raw: u32,
+    pub row: u32,
     pub col: u32
 }
 
 #[generate_trait]
 impl PositionImpl of PositionTrait {
     fn is_zero(self: Coordinates) -> bool {
-        if self.raw - self.col == 0 {
+        if self.row - self.col == 0 {
             return true;
         }
         false
     }
 
     fn is_equal(self: Coordinates, b: Coordinates) -> bool {
-        self.raw == b.raw && self.col == b.col
+        self.row == b.row && self.col == b.col
     }
 }
 // #[cfg(test)]

--- a/dojo-starter/src/systems/actions.cairo
+++ b/dojo-starter/src/systems/actions.cairo
@@ -383,7 +383,19 @@ pub mod actions {
                         };
                         let target_square: Piece = world
                             .read_model((piece.player, target_down_left));
-                        return !target_square.is_alive;
+                        // Check if the target square is alive (has a piece)
+                        if (target_square.is_alive) {
+                            // Check if the jump target square is not alive (has no piece)
+                            let target_jump = Coordinates {
+                                row: piece_row + 2, col: piece_col - 2
+                            };
+
+                            let target_square_jump: Piece = world
+                                .read_model((piece.player, target_jump));
+                            return !target_square_jump.is_alive;
+                        } else {
+                            return !target_square.is_alive;
+                        }
                     }
 
                     // Check down-right diagonal
@@ -393,7 +405,20 @@ pub mod actions {
                         };
                         let target_square: Piece = world
                             .read_model((piece.player, target_down_right));
-                        return !target_square.is_alive;
+                        
+                        // Check if the target square is alive (has a piece)
+                        if (target_square.is_alive) {
+                            // Check if the jump target square is not alive (has no piece)
+                            let target_jump = Coordinates {
+                                row: piece_row + 2, col: piece_col + 2
+                            };
+
+                            let target_square_jump: Piece = world
+                                .read_model((piece.player, target_jump));
+                            return !target_square_jump.is_alive;
+                        } else {
+                            return !target_square.is_alive;
+                        }
                     }
                     false
                 },

--- a/dojo-starter/src/systems/actions.cairo
+++ b/dojo-starter/src/systems/actions.cairo
@@ -40,7 +40,7 @@ pub mod actions {
             // Update the world state with the new data.
 
             // Create the pieces for the player. Upper side of the board.
-            let coord_01 = Coordinates { raw: 0, col: 1 };
+            let coord_01 = Coordinates { row: 0, col: 1 };
             let piece_01 = Piece {
                 player,
                 coordinates: coord_01,
@@ -48,7 +48,7 @@ pub mod actions {
                 is_king: false,
                 is_alive: true
             };
-            let coord_03 = Coordinates { raw: 0, col: 3 };
+            let coord_03 = Coordinates { row: 0, col: 3 };
             let piece_03 = Piece {
                 player,
                 coordinates: coord_03,
@@ -56,7 +56,7 @@ pub mod actions {
                 is_king: false,
                 is_alive: true
             };
-            let coord_05 = Coordinates { raw: 0, col: 5 };
+            let coord_05 = Coordinates { row: 0, col: 5 };
             let piece_05 = Piece {
                 player,
                 coordinates: coord_05,
@@ -64,7 +64,7 @@ pub mod actions {
                 is_king: false,
                 is_alive: true
             };
-            let coord_07 = Coordinates { raw: 0, col: 7 };
+            let coord_07 = Coordinates { row: 0, col: 7 };
             let piece_07 = Piece {
                 player,
                 coordinates: coord_07,
@@ -72,7 +72,7 @@ pub mod actions {
                 is_king: false,
                 is_alive: true
             };
-            let coord_10 = Coordinates { raw: 1, col: 0 };
+            let coord_10 = Coordinates { row: 1, col: 0 };
             let piece_10 = Piece {
                 player,
                 coordinates: coord_10,
@@ -80,7 +80,7 @@ pub mod actions {
                 is_king: false,
                 is_alive: true
             };
-            let coord_12 = Coordinates { raw: 1, col: 2 };
+            let coord_12 = Coordinates { row: 1, col: 2 };
             let piece_12 = Piece {
                 player,
                 coordinates: coord_12,
@@ -88,7 +88,7 @@ pub mod actions {
                 is_king: false,
                 is_alive: true
             };
-            let coord_14 = Coordinates { raw: 1, col: 4 };
+            let coord_14 = Coordinates { row: 1, col: 4 };
             let piece_14 = Piece {
                 player,
                 coordinates: coord_14,
@@ -96,7 +96,7 @@ pub mod actions {
                 is_king: false,
                 is_alive: true
             };
-            let coord_16 = Coordinates { raw: 1, col: 6 };
+            let coord_16 = Coordinates { row: 1, col: 6 };
             let piece_16 = Piece {
                 player,
                 coordinates: coord_16,
@@ -104,7 +104,7 @@ pub mod actions {
                 is_king: false,
                 is_alive: true
             };
-            let coord_21 = Coordinates { raw: 2, col: 1 };
+            let coord_21 = Coordinates { row: 2, col: 1 };
             let piece_21 = Piece {
                 player,
                 coordinates: coord_21,
@@ -112,7 +112,7 @@ pub mod actions {
                 is_king: false,
                 is_alive: true
             };
-            let coord_23 = Coordinates { raw: 2, col: 3 };
+            let coord_23 = Coordinates { row: 2, col: 3 };
             let piece_23 = Piece {
                 player,
                 coordinates: coord_23,
@@ -120,7 +120,7 @@ pub mod actions {
                 is_king: false,
                 is_alive: true
             };
-            let coord_25 = Coordinates { raw: 2, col: 5 };
+            let coord_25 = Coordinates { row: 2, col: 5 };
             let piece_25 = Piece {
                 player,
                 coordinates: coord_25,
@@ -128,7 +128,7 @@ pub mod actions {
                 is_king: false,
                 is_alive: true
             };
-            let coord_27 = Coordinates { raw: 2, col: 7 };
+            let coord_27 = Coordinates { row: 2, col: 7 };
             let piece_27 = Piece {
                 player,
                 coordinates: coord_27,
@@ -154,7 +154,7 @@ pub mod actions {
             // Important: For now we will use the same player for all the pieces.
 
             // Create the pieces for the player. Lower side of the board.
-            let coord_50 = Coordinates { raw: 5, col: 0 };
+            let coord_50 = Coordinates { row: 5, col: 0 };
             let piece_50 = Piece {
                 player,
                 coordinates: coord_50,
@@ -162,7 +162,7 @@ pub mod actions {
                 is_king: false,
                 is_alive: true
             };
-            let coord_52 = Coordinates { raw: 5, col: 2 };
+            let coord_52 = Coordinates { row: 5, col: 2 };
             let piece_52 = Piece {
                 player,
                 coordinates: coord_52,
@@ -170,7 +170,7 @@ pub mod actions {
                 is_king: false,
                 is_alive: true
             };
-            let coord_54 = Coordinates { raw: 5, col: 4 };
+            let coord_54 = Coordinates { row: 5, col: 4 };
             let piece_54 = Piece {
                 player,
                 coordinates: coord_54,
@@ -178,7 +178,7 @@ pub mod actions {
                 is_king: false,
                 is_alive: true
             };
-            let coord_56 = Coordinates { raw: 5, col: 6 };
+            let coord_56 = Coordinates { row: 5, col: 6 };
             let piece_56 = Piece {
                 player,
                 coordinates: coord_56,
@@ -186,7 +186,7 @@ pub mod actions {
                 is_king: false,
                 is_alive: true
             };
-            let coord_61 = Coordinates { raw: 6, col: 1 };
+            let coord_61 = Coordinates { row: 6, col: 1 };
             let piece_61 = Piece {
                 player,
                 coordinates: coord_61,
@@ -194,7 +194,7 @@ pub mod actions {
                 is_king: false,
                 is_alive: true
             };
-            let coord_63 = Coordinates { raw: 6, col: 3 };
+            let coord_63 = Coordinates { row: 6, col: 3 };
             let piece_63 = Piece {
                 player,
                 coordinates: coord_63,
@@ -202,7 +202,7 @@ pub mod actions {
                 is_king: false,
                 is_alive: true
             };
-            let coord_65 = Coordinates { raw: 6, col: 5 };
+            let coord_65 = Coordinates { row: 6, col: 5 };
             let piece_65 = Piece {
                 player,
                 coordinates: coord_65,
@@ -210,7 +210,7 @@ pub mod actions {
                 is_king: false,
                 is_alive: true
             };
-            let coord_67 = Coordinates { raw: 6, col: 7 };
+            let coord_67 = Coordinates { row: 6, col: 7 };
             let piece_67 = Piece {
                 player,
                 coordinates: coord_67,
@@ -218,7 +218,7 @@ pub mod actions {
                 is_king: false,
                 is_alive: true
             };
-            let coord_70 = Coordinates { raw: 7, col: 0 };
+            let coord_70 = Coordinates { row: 7, col: 0 };
             let piece_70 = Piece {
                 player,
                 coordinates: coord_70,
@@ -226,7 +226,7 @@ pub mod actions {
                 is_king: false,
                 is_alive: true
             };
-            let coord_72 = Coordinates { raw: 7, col: 2 };
+            let coord_72 = Coordinates { row: 7, col: 2 };
             let piece_72 = Piece {
                 player,
                 coordinates: coord_72,
@@ -234,7 +234,7 @@ pub mod actions {
                 is_king: false,
                 is_alive: true
             };
-            let coord_74 = Coordinates { raw: 7, col: 4 };
+            let coord_74 = Coordinates { row: 7, col: 4 };
             let piece_74 = Piece {
                 player,
                 coordinates: coord_74,
@@ -242,7 +242,7 @@ pub mod actions {
                 is_king: false,
                 is_alive: true
             };
-            let coord_76 = Coordinates { raw: 7, col: 6 };
+            let coord_76 = Coordinates { row: 7, col: 6 };
             let piece_76 = Piece {
                 player,
                 coordinates: coord_76,
@@ -361,7 +361,7 @@ pub mod actions {
 
         fn check_has_valid_moves(self: @ContractState, piece: Piece) -> bool {
             let world = self.world_default();
-            let piece_raw = piece.coordinates.raw;
+            let piece_row = piece.coordinates.row;
             let piece_col = piece.coordinates.col;
 
             // Only handling non-king pieces for now
@@ -372,14 +372,14 @@ pub mod actions {
             match piece.position {
                 Position::Up => {
                     // Check forward moves (down direction)
-                    if piece_raw + 1 >= 8 {
+                    if piece_row + 1 >= 8 {
                         return false;
                     }
 
                     // Check down-left diagonal
                     if piece_col > 0 {
                         let target_down_left = Coordinates {
-                            raw: piece_raw + 1, col: piece_col - 1
+                            row: piece_row + 1, col: piece_col - 1
                         };
                         let target_square: Piece = world
                             .read_model((piece.player, target_down_left));
@@ -389,7 +389,7 @@ pub mod actions {
                     // Check down-right diagonal
                     if piece_col + 1 < 8 {
                         let target_down_right = Coordinates {
-                            raw: piece_raw + 1, col: piece_col + 1
+                            row: piece_row + 1, col: piece_col + 1
                         };
                         let target_square: Piece = world
                             .read_model((piece.player, target_down_right));
@@ -399,13 +399,13 @@ pub mod actions {
                 },
                 Position::Down => {
                     // Check forward moves (up direction)
-                    if piece_raw == 0 {
+                    if piece_row == 0 {
                         return false;
                     }
 
                     // Check up-left diagonal
                     if piece_col > 0 {
-                        let target_up_left = Coordinates { raw: piece_raw - 1, col: piece_col - 1 };
+                        let target_up_left = Coordinates { row: piece_row - 1, col: piece_col - 1 };
                         let target_square: Piece = world.read_model((piece.player, target_up_left));
                         return !target_square.is_alive;
                     }
@@ -413,7 +413,7 @@ pub mod actions {
                     // Check up-right diagonal
                     if piece_col + 1 < 8 {
                         let target_up_right = Coordinates {
-                            raw: piece_raw - 1, col: piece_col + 1
+                            row: piece_row - 1, col: piece_col + 1
                         };
                         let target_square: Piece = world
                             .read_model((piece.player, target_up_right));
@@ -429,18 +429,18 @@ pub mod actions {
 
 // Todo: Improve this function to check if the new coordinates is valid.
 fn update_piece_position(mut piece: Piece, square: Piece) -> Piece {
-    piece.coordinates.raw = square.coordinates.raw;
+    piece.coordinates.row = square.coordinates.row;
     piece.coordinates.col = square.coordinates.col;
     piece
 }
 
 fn check_is_valid_position(coordinates: Coordinates) -> bool {
-    let raw = coordinates.raw;
+    let row = coordinates.row;
     let col = coordinates.col;
     // Check if the coordinates is out of bounds
-    if raw < 8 && col < 8 {
+    if row < 8 && col < 8 {
         // Check if the coordinates is valid on the board setup
-        match raw {
+        match row {
             0 => col == 1 || col == 3 || col == 5 || col == 7,
             1 => col == 0 || col == 2 || col == 4 || col == 6,
             2 => col == 1 || col == 3 || col == 5 || col == 7,

--- a/dojo-starter/src/tests/test_world.cairo
+++ b/dojo-starter/src/tests/test_world.cairo
@@ -31,12 +31,12 @@ mod tests {
         let mut world = spawn_test_world([ndef].span());
 
         // Test initial piece
-        let piece_position_77 = Coordinates { raw: 7, col: 7 };
+        let piece_position_77 = Coordinates { row: 7, col: 7 };
         let piece: Piece = world.read_model((caller, piece_position_77));
         assert(piece.position == Position::None && piece.is_alive == false, 'initial piece wrong');
 
         // Test write_model_test
-        let piece_vec = Coordinates { raw: 1, col: 1 };
+        let piece_vec = Coordinates { row: 1, col: 1 };
         let piece = Piece {
             player: caller,
             coordinates: piece_vec,
@@ -72,207 +72,207 @@ mod tests {
         assert(pieces.len() == 24, 'wrong number of pieces');
 
         // test zero row
-        let invalid_piece_position00 = Coordinates { raw: 0, col: 0 }; // Empty square
+        let invalid_piece_position00 = Coordinates { row: 0, col: 0 }; // Empty square
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Up, invalid_piece_position00);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position01 = Coordinates { raw: 0, col: 1 };
+        let invalid_piece_position01 = Coordinates { row: 0, col: 1 };
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Up, invalid_piece_position01);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position02 = Coordinates { raw: 0, col: 2 }; // Empty square
+        let invalid_piece_position02 = Coordinates { row: 0, col: 2 }; // Empty square
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Up, invalid_piece_position02);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position03 = Coordinates { raw: 0, col: 3 };
+        let invalid_piece_position03 = Coordinates { row: 0, col: 3 };
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Up, invalid_piece_position03);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position04 = Coordinates { raw: 0, col: 4 }; // Empty square
+        let invalid_piece_position04 = Coordinates { row: 0, col: 4 }; // Empty square
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Up, invalid_piece_position04);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position05 = Coordinates { raw: 0, col: 5 };
+        let invalid_piece_position05 = Coordinates { row: 0, col: 5 };
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Up, invalid_piece_position05);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position06 = Coordinates { raw: 0, col: 6 }; // Empty square
+        let invalid_piece_position06 = Coordinates { row: 0, col: 6 }; // Empty square
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Up, invalid_piece_position06);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position07 = Coordinates { raw: 0, col: 7 };
+        let invalid_piece_position07 = Coordinates { row: 0, col: 7 };
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Up, invalid_piece_position07);
         assert(!can_choose_piece, 'should be false');
 
         // test first row
-        let invalid_piece_position10 = Coordinates { raw: 1, col: 0 };
+        let invalid_piece_position10 = Coordinates { row: 1, col: 0 };
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Up, invalid_piece_position10);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position11 = Coordinates { raw: 1, col: 1 }; // Empty square
+        let invalid_piece_position11 = Coordinates { row: 1, col: 1 }; // Empty square
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Up, invalid_piece_position11);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position12 = Coordinates { raw: 1, col: 2 };
+        let invalid_piece_position12 = Coordinates { row: 1, col: 2 };
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Up, invalid_piece_position12);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position13 = Coordinates { raw: 1, col: 3 }; // Empty square
+        let invalid_piece_position13 = Coordinates { row: 1, col: 3 }; // Empty square
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Up, invalid_piece_position13);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position14 = Coordinates { raw: 1, col: 4 };
+        let invalid_piece_position14 = Coordinates { row: 1, col: 4 };
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Up, invalid_piece_position14);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position15 = Coordinates { raw: 1, col: 5 }; // Empty square
+        let invalid_piece_position15 = Coordinates { row: 1, col: 5 }; // Empty square
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Up, invalid_piece_position15);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position16 = Coordinates { raw: 1, col: 6 };
+        let invalid_piece_position16 = Coordinates { row: 1, col: 6 };
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Up, invalid_piece_position16);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position17 = Coordinates { raw: 1, col: 7 }; // Empty square
+        let invalid_piece_position17 = Coordinates { row: 1, col: 7 }; // Empty square
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Up, invalid_piece_position17);
         assert(!can_choose_piece, 'should be false');
 
         // test second row
-        let invalid_piece_position20 = Coordinates { raw: 2, col: 0 }; // Empty square
+        let invalid_piece_position20 = Coordinates { row: 2, col: 0 }; // Empty square
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Up, invalid_piece_position20);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position22 = Coordinates { raw: 2, col: 2 }; // Empty square
+        let invalid_piece_position22 = Coordinates { row: 2, col: 2 }; // Empty square
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Up, invalid_piece_position22);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position24 = Coordinates { raw: 2, col: 4 }; // Empty square
+        let invalid_piece_position24 = Coordinates { row: 2, col: 4 }; // Empty square
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Up, invalid_piece_position24);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position26 = Coordinates { raw: 2, col: 6 }; // Empty square
+        let invalid_piece_position26 = Coordinates { row: 2, col: 6 }; // Empty square
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Up, invalid_piece_position26);
         assert(!can_choose_piece, 'should be false');
 
         // test fifth row
-        let invalid_piece_position51 = Coordinates { raw: 5, col: 1 }; // Empty square
+        let invalid_piece_position51 = Coordinates { row: 5, col: 1 }; // Empty square
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Up, invalid_piece_position51);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position53 = Coordinates { raw: 5, col: 3 }; // Empty square
+        let invalid_piece_position53 = Coordinates { row: 5, col: 3 }; // Empty square
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Up, invalid_piece_position53);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position55 = Coordinates { raw: 5, col: 5 }; // Empty square
+        let invalid_piece_position55 = Coordinates { row: 5, col: 5 }; // Empty square
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Up, invalid_piece_position55);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position57 = Coordinates { raw: 5, col: 7 }; // Empty square
+        let invalid_piece_position57 = Coordinates { row: 5, col: 7 }; // Empty square
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Up, invalid_piece_position57);
         assert(!can_choose_piece, 'should be false');
 
         // test sixth row
-        let invalid_piece_position60 = Coordinates { raw: 6, col: 0 }; // Empty square
+        let invalid_piece_position60 = Coordinates { row: 6, col: 0 }; // Empty square
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Down, invalid_piece_position60);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position61 = Coordinates { raw: 6, col: 1 };
+        let invalid_piece_position61 = Coordinates { row: 6, col: 1 };
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Down, invalid_piece_position61);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position62 = Coordinates { raw: 6, col: 2 }; // Empty square
+        let invalid_piece_position62 = Coordinates { row: 6, col: 2 }; // Empty square
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Down, invalid_piece_position62);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position63 = Coordinates { raw: 6, col: 3 };
+        let invalid_piece_position63 = Coordinates { row: 6, col: 3 };
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Down, invalid_piece_position63);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position64 = Coordinates { raw: 6, col: 4 }; // Empty square
+        let invalid_piece_position64 = Coordinates { row: 6, col: 4 }; // Empty square
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Down, invalid_piece_position64);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position65 = Coordinates { raw: 6, col: 5 };
+        let invalid_piece_position65 = Coordinates { row: 6, col: 5 };
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Down, invalid_piece_position65);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position66 = Coordinates { raw: 6, col: 6 }; // Empty square
+        let invalid_piece_position66 = Coordinates { row: 6, col: 6 }; // Empty square
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Down, invalid_piece_position66);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position67 = Coordinates { raw: 6, col: 7 };
+        let invalid_piece_position67 = Coordinates { row: 6, col: 7 };
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Down, invalid_piece_position67);
         assert(!can_choose_piece, 'should be false');
 
         // test seventh row
-        let invalid_piece_position70 = Coordinates { raw: 7, col: 0 };
+        let invalid_piece_position70 = Coordinates { row: 7, col: 0 };
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Down, invalid_piece_position70);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position71 = Coordinates { raw: 7, col: 1 };
+        let invalid_piece_position71 = Coordinates { row: 7, col: 1 };
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Down, invalid_piece_position71);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position72 = Coordinates { raw: 7, col: 2 };
+        let invalid_piece_position72 = Coordinates { row: 7, col: 2 };
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Down, invalid_piece_position72);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position73 = Coordinates { raw: 7, col: 3 };
+        let invalid_piece_position73 = Coordinates { row: 7, col: 3 };
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Down, invalid_piece_position73);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position74 = Coordinates { raw: 7, col: 4 };
+        let invalid_piece_position74 = Coordinates { row: 7, col: 4 };
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Down, invalid_piece_position74);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position75 = Coordinates { raw: 7, col: 5 };
+        let invalid_piece_position75 = Coordinates { row: 7, col: 5 };
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Down, invalid_piece_position75);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position76 = Coordinates { raw: 7, col: 6 };
+        let invalid_piece_position76 = Coordinates { row: 7, col: 6 };
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Down, invalid_piece_position76);
         assert(!can_choose_piece, 'should be false');
 
-        let invalid_piece_position77 = Coordinates { raw: 7, col: 7 };
+        let invalid_piece_position77 = Coordinates { row: 7, col: 7 };
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Down, invalid_piece_position77);
         assert(!can_choose_piece, 'should be false');
@@ -290,41 +290,41 @@ mod tests {
         actions_system.spawn();
 
         // test third row
-        let valid_piece_position21 = Coordinates { raw: 2, col: 1 };
+        let valid_piece_position21 = Coordinates { row: 2, col: 1 };
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Up, valid_piece_position21);
         assert(can_choose_piece, 'should be true');
-        let valid_piece_position23 = Coordinates { raw: 2, col: 3 };
+        let valid_piece_position23 = Coordinates { row: 2, col: 3 };
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Up, valid_piece_position23);
         assert(can_choose_piece, 'should be true');
 
-        let valid_piece_position25 = Coordinates { raw: 2, col: 5 };
+        let valid_piece_position25 = Coordinates { row: 2, col: 5 };
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Up, valid_piece_position25);
         assert(can_choose_piece, 'should be true');
 
-        let valid_piece_position27 = Coordinates { raw: 2, col: 7 };
+        let valid_piece_position27 = Coordinates { row: 2, col: 7 };
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Up, valid_piece_position27);
         assert(can_choose_piece, 'should be true');
         // test fifth row
-        let valid_piece_position50 = Coordinates { raw: 5, col: 0 };
+        let valid_piece_position50 = Coordinates { row: 5, col: 0 };
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Down, valid_piece_position50);
         assert(can_choose_piece, 'should be true');
 
-        let valid_piece_position52 = Coordinates { raw: 5, col: 2 };
+        let valid_piece_position52 = Coordinates { row: 5, col: 2 };
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Down, valid_piece_position52);
         assert(can_choose_piece, 'should be true');
 
-        let valid_piece_position54 = Coordinates { raw: 5, col: 4 };
+        let valid_piece_position54 = Coordinates { row: 5, col: 4 };
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Down, valid_piece_position54);
         assert(can_choose_piece, 'should be true');
 
-        let valid_piece_position56 = Coordinates { raw: 5, col: 6 };
+        let valid_piece_position56 = Coordinates { row: 5, col: 6 };
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Down, valid_piece_position56);
         assert(can_choose_piece, 'should be true');
@@ -342,13 +342,13 @@ mod tests {
         let actions_system = IActionsDispatcher { contract_address };
 
         actions_system.spawn();
-        let valid_piece_position = Coordinates { raw: 2, col: 1 };
+        let valid_piece_position = Coordinates { row: 2, col: 1 };
 
         let can_choose_piece = actions_system.can_choose_piece(Position::Up, valid_piece_position);
         assert(can_choose_piece, 'can_choose_piece failed');
 
         let current_piece = world.read_model((caller, valid_piece_position));
-        let new_coordinates_position = Coordinates { raw: 3, col: 1 };
+        let new_coordinates_position = Coordinates { row: 3, col: 1 };
         actions_system.move_piece(current_piece, new_coordinates_position);
     }
     #[test]
@@ -363,13 +363,13 @@ mod tests {
         let actions_system = IActionsDispatcher { contract_address };
 
         actions_system.spawn();
-        let valid_piece_position = Coordinates { raw: 2, col: 7 };
+        let valid_piece_position = Coordinates { row: 2, col: 7 };
 
         let can_choose_piece = actions_system.can_choose_piece(Position::Up, valid_piece_position);
         assert(can_choose_piece, 'can_choose_piece failed');
 
         let current_piece = world.read_model((caller, valid_piece_position));
-        let new_coordinates_position = Coordinates { raw: 3, col: 8 };
+        let new_coordinates_position = Coordinates { row: 3, col: 8 };
         actions_system.move_piece(current_piece, new_coordinates_position);
     }
 
@@ -384,11 +384,11 @@ mod tests {
         let actions_system = IActionsDispatcher { contract_address };
 
         actions_system.spawn();
-        let valid_piece_position = Coordinates { raw: 2, col: 1 };
+        let valid_piece_position = Coordinates { row: 2, col: 1 };
         let initial_piece_position: Piece = world.read_model((caller, valid_piece_position));
 
         assert(
-            initial_piece_position.coordinates.raw == 2
+            initial_piece_position.coordinates.row == 2
                 && initial_piece_position.coordinates.col == 1,
             'wrong initial piece'
         );
@@ -398,16 +398,125 @@ mod tests {
         let can_choose_piece = actions_system.can_choose_piece(Position::Up, valid_piece_position);
         assert(can_choose_piece, 'can_choose_piece failed');
         let current_piece: Piece = world.read_model((caller, valid_piece_position));
-        let new_coordinates_position = Coordinates { raw: 3, col: 0 };
+        let new_coordinates_position = Coordinates { row: 3, col: 0 };
         actions_system.move_piece(current_piece, new_coordinates_position);
 
         let new_position: Piece = world.read_model((caller, new_coordinates_position));
 
-        assert!(new_position.coordinates.raw == 3, "piece x is wrong");
+        assert!(new_position.coordinates.row == 3, "piece x is wrong");
         assert!(new_position.coordinates.col == 0, "piece y is wrong");
         assert!(new_position.is_alive == true, "piece is not alive");
         assert!(new_position.is_king == false, "piece is king");
     }
+
+    #[test]
+    fn test_move_piece23_down_left() {
+        let caller = starknet::contract_address_const::<0x0>();
+
+        let ndef = namespace_def();
+        let mut world = spawn_test_world([ndef].span());
+
+        let (contract_address, _) = world.dns(@"actions").unwrap();
+        let actions_system = IActionsDispatcher { contract_address };
+
+        actions_system.spawn();
+        let valid_piece_position = Coordinates { row: 2, col: 3 };
+        let initial_piece_position: Piece = world.read_model((caller, valid_piece_position));
+
+        assert(
+            initial_piece_position.coordinates.row == 2
+                && initial_piece_position.coordinates.col == 3,
+            'wrong initial piece'
+        );
+        assert(initial_piece_position.is_king == false, 'wrong initial piece');
+        assert(initial_piece_position.is_alive == true, 'wrong initial piece');
+
+        let can_choose_piece = actions_system.can_choose_piece(Position::Up, valid_piece_position);
+        assert(can_choose_piece, 'can_choose_piece failed');
+        let current_piece: Piece = world.read_model((caller, valid_piece_position));
+        let new_coordinates_position = Coordinates { row: 3, col: 2 };
+        actions_system.move_piece(current_piece, new_coordinates_position);
+
+        let new_position: Piece = world.read_model((caller, new_coordinates_position));
+
+        assert!(new_position.coordinates.row == 3, "piece x is wrong");
+        assert!(new_position.coordinates.col == 2, "piece y is wrong");
+        assert!(new_position.is_alive == true, "piece is not alive");
+        assert!(new_position.is_king == false, "piece is king");
+    }
+
+    #[test]
+    fn test_move_piece25_down_left() {
+        let caller = starknet::contract_address_const::<0x0>();
+
+        let ndef = namespace_def();
+        let mut world = spawn_test_world([ndef].span());
+
+        let (contract_address, _) = world.dns(@"actions").unwrap();
+        let actions_system = IActionsDispatcher { contract_address };
+
+        actions_system.spawn();
+        let valid_piece_position = Coordinates { row: 2, col: 5 };
+        let initial_piece_position: Piece = world.read_model((caller, valid_piece_position));
+
+        assert(
+            initial_piece_position.coordinates.row == 2
+                && initial_piece_position.coordinates.col == 5,
+            'wrong initial piece'
+        );
+        assert(initial_piece_position.is_king == false, 'wrong initial piece');
+        assert(initial_piece_position.is_alive == true, 'wrong initial piece');
+
+        let can_choose_piece = actions_system.can_choose_piece(Position::Up, valid_piece_position);
+        assert(can_choose_piece, 'can_choose_piece failed');
+        let current_piece: Piece = world.read_model((caller, valid_piece_position));
+        let new_coordinates_position = Coordinates { row: 3, col: 4 };
+        actions_system.move_piece(current_piece, new_coordinates_position);
+
+        let new_position: Piece = world.read_model((caller, new_coordinates_position));
+
+        assert!(new_position.coordinates.row == 3, "piece x is wrong");
+        assert!(new_position.coordinates.col == 4, "piece y is wrong");
+        assert!(new_position.is_alive == true, "piece is not alive");
+        assert!(new_position.is_king == false, "piece is king");
+    }    
+
+    #[test]
+    fn test_move_piece27_down_left() {
+        let caller = starknet::contract_address_const::<0x0>();
+
+        let ndef = namespace_def();
+        let mut world = spawn_test_world([ndef].span());
+
+        let (contract_address, _) = world.dns(@"actions").unwrap();
+        let actions_system = IActionsDispatcher { contract_address };
+
+        actions_system.spawn();
+        let valid_piece_position = Coordinates { row: 2, col: 7 };
+        let initial_piece_position: Piece = world.read_model((caller, valid_piece_position));
+
+        assert(
+            initial_piece_position.coordinates.row == 2
+                && initial_piece_position.coordinates.col == 7,
+            'wrong initial piece'
+        );
+        assert(initial_piece_position.is_king == false, 'wrong initial piece');
+        assert(initial_piece_position.is_alive == true, 'wrong initial piece');
+
+        let can_choose_piece = actions_system.can_choose_piece(Position::Up, valid_piece_position);
+        assert(can_choose_piece, 'can_choose_piece failed');
+        let current_piece: Piece = world.read_model((caller, valid_piece_position));
+        let new_coordinates_position = Coordinates { row: 3, col: 6 };
+        actions_system.move_piece(current_piece, new_coordinates_position);
+
+        let new_position: Piece = world.read_model((caller, new_coordinates_position));
+
+        assert!(new_position.coordinates.row == 3, "piece x is wrong");
+        assert!(new_position.coordinates.col == 6, "piece y is wrong");
+        assert!(new_position.is_alive == true, "piece is not alive");
+        assert!(new_position.is_king == false, "piece is king");
+    }    
+
     #[test]
     fn test_move_piece21_down_right() {
         let caller = starknet::contract_address_const::<0x0>();
@@ -419,11 +528,11 @@ mod tests {
         let actions_system = IActionsDispatcher { contract_address };
 
         actions_system.spawn();
-        let valid_piece_position = Coordinates { raw: 2, col: 1 };
+        let valid_piece_position = Coordinates { row: 2, col: 1 };
         let initial_piece_position: Piece = world.read_model((caller, valid_piece_position));
 
         assert(
-            initial_piece_position.coordinates.raw == 2
+            initial_piece_position.coordinates.row == 2
                 && initial_piece_position.coordinates.col == 1,
             'wrong initial piece'
         );
@@ -433,12 +542,12 @@ mod tests {
         let can_choose_piece = actions_system.can_choose_piece(Position::Up, valid_piece_position);
         assert(can_choose_piece, 'can_choose_piece failed');
         let current_piece: Piece = world.read_model((caller, valid_piece_position));
-        let new_coordinates_position = Coordinates { raw: 3, col: 2 };
+        let new_coordinates_position = Coordinates { row: 3, col: 2 };
         actions_system.move_piece(current_piece, new_coordinates_position);
 
         let new_position: Piece = world.read_model((caller, new_coordinates_position));
 
-        assert!(new_position.coordinates.raw == 3, "piece x is wrong");
+        assert!(new_position.coordinates.row == 3, "piece x is wrong");
         assert!(new_position.coordinates.col == 2, "piece y is wrong");
         assert!(new_position.is_alive == true, "piece is not alive");
         assert!(new_position.is_king == false, "piece is king");
@@ -455,11 +564,11 @@ mod tests {
         let actions_system = IActionsDispatcher { contract_address };
 
         actions_system.spawn();
-        let valid_piece_position = Coordinates { raw: 2, col: 1 };
+        let valid_piece_position = Coordinates { row: 2, col: 1 };
         let initial_piece_position: Piece = world.read_model((caller, valid_piece_position));
 
         assert(
-            initial_piece_position.coordinates.raw == 2
+            initial_piece_position.coordinates.row == 2
                 && initial_piece_position.coordinates.col == 1,
             'wrong initial piece'
         );
@@ -469,27 +578,27 @@ mod tests {
         let can_choose_piece = actions_system.can_choose_piece(Position::Up, valid_piece_position);
         assert(can_choose_piece, 'can_choose_piece failed');
         let current_piece: Piece = world.read_model((caller, valid_piece_position));
-        let new_coordinates_position = Coordinates { raw: 3, col: 2 };
+        let new_coordinates_position = Coordinates { row: 3, col: 2 };
         actions_system.move_piece(current_piece, new_coordinates_position);
 
         let new_position: Piece = world.read_model((caller, new_coordinates_position));
 
-        assert!(new_position.coordinates.raw == 3, "piece x is wrong");
+        assert!(new_position.coordinates.row == 3, "piece x is wrong");
         assert!(new_position.coordinates.col == 2, "piece y is wrong");
         assert!(new_position.is_alive == true, "piece is not alive");
         assert!(new_position.is_king == false, "piece is king");
 
-        let valid_piece_position56 = Coordinates { raw: 5, col: 6 };
+        let valid_piece_position56 = Coordinates { row: 5, col: 6 };
         let can_choose_piece = actions_system
             .can_choose_piece(Position::Down, valid_piece_position56);
         assert(can_choose_piece, 'can_choose_piece failed');
         let current_piece: Piece = world.read_model((caller, valid_piece_position56));
-        let new_coordinates_position = Coordinates { raw: 4, col: 5 };
+        let new_coordinates_position = Coordinates { row: 4, col: 5 };
         actions_system.move_piece(current_piece, new_coordinates_position);
 
         let new_position: Piece = world.read_model((caller, new_coordinates_position));
 
-        assert!(new_position.coordinates.raw == 4, "piece x is wrong");
+        assert!(new_position.coordinates.row == 4, "piece x is wrong");
         assert!(new_position.coordinates.col == 5, "piece y is wrong");
         assert!(new_position.is_alive == true, "piece is not alive");
         assert!(new_position.is_king == false, "piece is king");


### PR DESCRIPTION
Need to add the king/queen movement, another Dojo model for the player to keep track of their remaining pieces and add game over (win condition) checking which could be implemented after making the Dojo model.

Also, we need to refactor the spawn to make it more modular to make it easier to implement with 2 players and initialize all the squares properly.