### PR TITLE
feat: configure mkcert to enable controller usage without ngrok

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,41 @@ pnpm dev
 
 To test the connection with the controller, follow these steps:
 
-Use ngrok: ngrok http 5173.
+### Configure mkcert for HTTPS
+
+You can configure mkcert to enable HTTPS and work with the controller directly, without requiring ngrok. Follow the steps below based on your operating system:
+
+#### Windows
+
+For Windows installation and configuration of mkcert, follow the guide in the link below:\
+[mkcert Windows Setup Guide](https://github.com/FiloSottile/mkcert/issues/357#issuecomment-1466762021)
+
+#### Linux
+
+For Linux installation and configuration of mkcert, follow the official guidelines provided in these links:
+
+-   [Linux Installation Steps](https://github.com/FiloSottile/mkcert#linux)
+-   [mkcert Installation Guide](https://github.com/FiloSottile/mkcert?tab=readme-ov-file#mkcert)
+
+These guides provide detailed steps to set up mkcert on various Linux distributions.
+
+#### Check HTTPS Security in the Browser
+
+-   After completing the mkcert configuration, visit your local site.
+-   The browser should display **"This page is secure (valid HTTPS)"**.
+-   If the page shows as **insecure**, the mkcert configuration is incorrect.
+
+  
+### Alternative to mkcert: Use ngrok
+
+Run the following command to use ngrok:
+```bash
+ngrok http 5173
+```
+
 With this, you will be able to use the connection with the controller.
 
-Related commands for the Katana slot:
+### Related commands for the Katana slot:
 
 ```bash
 slot deployments logs checkers-controller-1 katana -f

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -2,10 +2,10 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import topLevelAwait from "vite-plugin-top-level-await";
 import wasm from "vite-plugin-wasm";
-// import mkcert from "vite-plugin-mkcert";
+import mkcert from "vite-plugin-mkcert";
 //if we import this plugin we can use the controller without ngrok
 
 // https://vitejs.dev/config/
 export default defineConfig({
-    plugins: [react(), wasm(), topLevelAwait()],
+    plugins: [react(), wasm(), topLevelAwait(), mkcert()],
 });


### PR DESCRIPTION
# Pull Request | Checkers

## 1. Issue Link
- Closes #24 

## 2. Brief Description
This PR configures mkcert in the vite.config.ts file to enable HTTPS and allows the controller to work without requiring ngrok. This simplifies the setup process and improves local development.

## 3. Changes Made
- [x]  Added `mkcert` dependency to `vite.config.ts`
- [x] Enabled HTTPS support in the local development server
 
## 4. Checklist
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] Code follows standards

## 5. Evidence
https://www.loom.com/share/4a4d295c519a4da7b35b1130342f34a3?sid=45df9d24-384d-42e8-8131-360910d3a135

## 6. Additional Notes
- The controller now works directly with HTTPS using mkcert.
- No need for ngrok for secure local development.

## 7. Installation and Configuration Steps for mkcert

### **Windows**
Follow the steps below to install and configure mkcert for Windows (steps illustrated in the image provided):

1. **Install mkcert in WSL2**: 
    - Install mkcert using your WSL2 environment as usual.

2. **Run Command**:
    - Run the following command from WSL2:
    ```bash
    mkcert -install
    ```
3. **Copy Root CA Certificate**: 
    - Copy the root CA certificate from `/usr/local/share/ca-certificates` to any directory accessible from Windows. For example:
    ```bash
    cp /usr/local/share/ca-certificates/mkcert_development_CA_xxxx.crt /mnt/d/
    ```
4. **Import Certificate**:
    -  Double-click the certificate (e.g., D:\mkcert_development_CA_xxxx.crt) to open it.
    -  Click Install Certificate and choose Trusted Root Certification Authorities.

5. **Verify Installation**:
    -  Open the Run dialog (Windows + R) and type:
        ```bash
        certmgr.msc
        ```
    -  Ensure that the mkcert certificate is listed under Trusted Root Certification Authorities.

### Linux Installation

For installing and configuring mkcert on Linux, follow the official guidelines provided in the links below:  

- [Linux Installation Steps](https://github.com/FiloSottile/mkcert#linux)  
- [mkcert Installation Guide](https://github.com/FiloSottile/mkcert?tab=readme-ov-file#mkcert)  

These guides provide detailed steps to set up mkcert on various Linux distributions.  

### Check HTTPS Security in the Browser

- After completing the mkcert configuration, visit your local site.  
- The browser should display **"This page is secure (valid HTTPS)"**.  
- If the page shows as **insecure**, the mkcert configuration is incorrect.

Example of a secure page:  
![image](https://github.com/user-attachments/assets/7a433416-5177-4209-9303-dab9eafb006a)



